### PR TITLE
graphdb.js callback calling and emtpy array in loadRecords

### DIFF
--- a/lib/orientdb/db.js
+++ b/lib/orientdb/db.js
@@ -408,13 +408,16 @@ Db.prototype.loadRecords = function(rids, options, callback) {
 
     var records = [];
     var ridsLength = rids.length;
+    if (ridsLength === 0) {
+        return callback(undefined, records);
+    }
     for (var i = 0; i < ridsLength; i++) {
         this.loadRecord(rids[i], options, function(err, record) {
             if (err) { return callback(err); }
             records.push(record);
 
             if (records.length === ridsLength) {
-                callback(undefined, records);
+                return callback(undefined, records);
             }
         });
     }

--- a/lib/orientdb/graphdb.js
+++ b/lib/orientdb/graphdb.js
@@ -21,7 +21,7 @@ function checkForGraphSchema(self, callback) {
         if (cluster === null) {
             self.createClass("ORIDs", callback);
         } else {
-            callback();
+            return callback();
         }
     };
 
@@ -34,7 +34,7 @@ function checkForGraphSchema(self, callback) {
                 self.command("alter class " + className + " shortname " + classShortName, callback);
             });
         } else {
-            callback();
+            return callback();
         }
     };
 
@@ -114,7 +114,7 @@ GraphDb.prototype.createEdge = function(sourceVertex, destVertex, hash, callback
 
                 parser.mergeHashes(destVertex, savedDestVertex);
 
-                callback(undefined, edge);
+                return callback(undefined, edge);
             });
 
         });
@@ -139,7 +139,7 @@ function getEdgesByDirection(self, sourceVertex, direction, label, callback) {
     }
     var edgesRids = sourceVertex[direction];
     if (!edgesRids || edgesRids.length === 0) {
-        callback(undefined, []);
+        return callback(undefined, []);
     }
 
     var edges = [];
@@ -154,7 +154,7 @@ function getEdgesByDirection(self, sourceVertex, direction, label, callback) {
             }
 
             if (loadedEdges === edgesRidsLength) {
-                callback(undefined, edges);
+                return callback(undefined, edges);
             }
         });
     }


### PR DESCRIPTION
graphdb.js wasn't correctly calling callbacks and db.loadRecords wasn't handling the case where the input array of rids is empty
