### PR TITLE
error during server.init gets propagated in connect

### DIFF
--- a/lib/orientdb/connection/server.js
+++ b/lib/orientdb/connection/server.js
@@ -43,7 +43,9 @@ Server.prototype.connect = function(callback) {
     var self = this;
     callback = callback || EMPTY_FUNCTION;
 
-    self.init(function() {
+    self.init(function(err) {
+
+        if (err) { return callback(err); }
 
         var data = {
             user_name: self.userName,


### PR DESCRIPTION
this fix allows the ECONNREFUSED error to get back to the server.connect caller.
