### PR TITLE
handling weird stuff sent by the server along with errors

### DIFF
--- a/lib/orientdb/connection/parser.js
+++ b/lib/orientdb/connection/parser.js
@@ -920,7 +920,17 @@ var canReadError = function(buf, offset) {
         if (!canReadByte(buf, offset)) {
             return false;
         }
-        more = readByte(buf, offset);
+        var hasMore = readByte(buf, offset );
+        while(hasMore > 1)//handles weird stuff sent by the server.
+        {
+            offset += BYTES_BYTE;
+            if (!canReadByte(buf, offset)) {
+                return false;
+            }
+            hasMore = readByte(buf, offset );
+        }
+
+        more = (hasMore===1);
         offset += BYTES_BYTE;
     }
     return true;
@@ -949,7 +959,14 @@ var readError = function(buf, objOffset) {
         // add to results
         errors.push(error);
 
-        more = readByte(buf, offset);
+        var hasMore = readByte(buf, offset );
+        while(hasMore > 1)//handles weird stuff sent by the server.
+        {
+            offset += BYTES_BYTE;
+            hasMore = readByte(buf, offset );
+        }
+
+        more = (hasMore===1);
         offset += BYTES_BYTE;
     }
 


### PR DESCRIPTION
orientdb server sent me a bunch of 255 values before the 0 indicating
end of error, so i added a continuous readByte while waiting for 0
or 1 in the error handling

i got the error using orientdb-1.2.0-20120930.180521-49-distribution

looks like it's still there using the latest snapshot too, i'm still trying to locate the bug in the db, but the 255 sent by the db were breaking the driver hence this fix :)
