### PR TITLE
added db.dropClass

### DIFF
--- a/lib/orientdb/db.js
+++ b/lib/orientdb/db.js
@@ -847,6 +847,24 @@ Db.prototype.createClass = function(className, superClassName, callback) {
     });
 };
 
+Db.prototype.dropClass = function(className, callback) {
+    callback = callback || EMPTY_FUNCTION;
+
+    var self = this;
+
+    self.command("DROP CLASS " + className, function(err) {
+
+        if (err) { return callback(err); }
+
+        self.reload(function(err) {
+
+            if (err) { return callback(err); }
+
+            callback();
+        });
+    });
+};
+
 Db.prototype.countRecordsInCluster = function(clusterName, callback) {
     callback = callback || EMPTY_FUNCTION;
 

--- a/test/cascading_save.js
+++ b/test/cascading_save.js
@@ -96,7 +96,11 @@ db.open(function(err) {
             assert(!parser.isUndefined(savedDoc.linked_map.link1["@class"]));
             assert(!parser.isUndefined(savedDoc.linked_map.link1["@version"]));
 
-            db.close();
+            unprepareDatabase(function(err) {
+                assert(!err, err);
+
+                db.close();
+            });
         });
     });
 });
@@ -125,4 +129,12 @@ function prepareDatabase(callback) {
         });
     });
 }
-        
+
+
+function unprepareDatabase(callback) {
+    db.dropClass("subClass", function(err) {
+        if (err) return callback(err);
+
+        db.dropClass("mainClass", callback);
+    });
+}

--- a/test/embedded_map.js
+++ b/test/embedded_map.js
@@ -114,9 +114,11 @@ function prepareDatabase(callback) {
     });
 }
 
-// TODO complete this functionality when the following issue is solved
-// https://github.com/gabipetrovay/node-orientdb/issues/83
 function unprepareDatabase(callback) {
-    callback();
+    graphdb.dropClass("VEdge", function(err) {
+        if (err) return callback(err);
+
+        graphdb.dropClass("VNode", callback);
+    });
 }
 

--- a/test/graph_with_additional_mandatory_fields.js
+++ b/test/graph_with_additional_mandatory_fields.js
@@ -57,7 +57,11 @@ graphdb.open(function(err) {
                     assert.equal("value1", edge.embed.key);
                     assert(!parser.isUndefined(edge["@rid"]));
 
-                    graphdb.close()
+                    unprepareDatabase(function(err) {
+                        assert(!err, err);
+
+                        graphdb.close()
+                    });
                 });
             });
         });
@@ -102,5 +106,13 @@ function prepareDatabase(callback) {
                 });
             });
         });
+    });
+}
+
+function unprepareDatabase(callback) {
+    graphdb.dropClass("VertexWithMandatoryFields", function(err) {
+        if (err) return callback(err);
+
+        graphdb.dropClass("EdgeWithMandatoryFields", callback);
     });
 }


### PR DESCRIPTION
An important difference with createClass is that dropClass DOES NOT delete the associated cluster (while createClasse also creates a new cluster)
The rationale is that cluster contains data and I don't think it's sane to delete them automatically: it's up to the developer
