### PR TITLE
Compatibility with storage configuration v4(r7384)

### DIFF
--- a/lib/orientdb/connection/parser.js
+++ b/lib/orientdb/connection/parser.js
@@ -880,6 +880,10 @@ var parseConfiguration = function(configString) {
     config.localeCountry = read(values[index++]);
     config.dateFormat = read(values[index++]);
     config.dateTimeFormat = read(values[index++]);
+    if (config.version >= 4) {
+        config.timeZone = read(values[index++]);
+        config.charset = read(values[index++]);
+    }
     if (config.version > 1) {
         index = phySegmentFromStream(config, config.version, values, index);
     }


### PR DESCRIPTION
Here is a fix for the version 4 of serialization of Storage Configuration (r7154 and r7157 in orient repository) which will probably be released in 1.3.0

From java implementation (OStrageConfiguration.java):
    // @COMPATIBILTY 1.2.0
    if (version >= 4) {
      timeZone = TimeZone.getTimeZone(read(values[index++]));
      charset = read(values[index++]);
    }
