### PR TITLE
evaluating "step" library

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "underscore" : "*"
     },
     "devDependencies"   : {
-        "tap"       : "0.3.1"
+        "tap"       : "0.3.1",
+        "step"      : "*"
     },
     "main"              : "./lib/orientdb/index",
     "directories"       : { "lib" : "./lib/orientdb" },


### PR DESCRIPTION
A user in the mailing list https://groups.google.com/forum/#!msg/orient-database/6qa-6Dw-Yz8/0uuasBrg-OcJ suggested to use an helper library to reduce the indentation of test code

I've ported a test to see how it looks. @gabipetrovay and everyone interested: what do you think?
