### PR TITLE
Add deprecation notice.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,10 @@
+> **Warning** This package is no longer maintained and is not compatible with newer versions of OrientDB. You should use the official node.js driver for OrientDB [Oriento](https://github.com/codemix/oriento) which is based on this work.
+
 Introduction
 ========
 
 This is a node.js driver for OrientDB using the OrientDB binary protocol.
+
 
 Installation
 ========


### PR DESCRIPTION
Since this package is no longer being maintained, see [oriento](/codemix/oriento) for the official node.js driver, which is based on a fork of this project.